### PR TITLE
 Refactoring the server/service packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can use the various components that make TySug individually or as a whole.
 
 
 ### Using a different algorithm
-if you want to use a different algorithm, simply wrap your algorithm in a `finder.AlgWrapper` compatible type and pass 
+if you want to use a different algorithm, simply wrap your algorithm in a `finder.Algorithm` compatible type and pass 
 it as argument to the Finder. You can find inspiration in the unit-tests / examples.
 
 Possible considerations:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ var someAlgorithm finder.AlgWrapper = func(a, b string) float64 {
     return 1 - (score / float64(ml))
 }
 
-sug := tysug.New([]list, optSetAlgorithm(someAlgorithm))
+sug := finder.New([]list, finder.OptSetAlgorithm(someAlgorithm))
 bestMatch, score := sug.Find(input)
 // Here score might be 0.8 for a string of length 10, with 2 mutations
 ```
@@ -106,7 +106,7 @@ func SuggestAlternative(email string, domains []string) (string, float64) {
     localPart := email[:i]
     hostname := email[i+1:]
     
-    sug, _ := tysug.New(domains)
+    sug, _ := finder.New(domains)
     alternative, score := sug.Find(hostname)
     
     if score > 0.9 {

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -76,7 +76,7 @@ func TestAlgorithms(t *testing.T) {
 
 	for name, alg := range algorithms {
 		t.Run(name, func(t *testing.T) {
-			sug, _ := finder.New(domains, finder.OptSetAlgorithm(alg))
+			sug, _ := finder.New(domains, finder.WithAlgorithm(alg))
 
 			// Running combination tests for each domain, against our reference list.
 			for expectedDomain, emailsToTest := range testData {
@@ -95,7 +95,7 @@ func TestAlgorithms(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expect := "example"
-	sug, _ := finder.New([]string{expect, "ample"}, finder.OptSetAlgorithm(algorithms[defaultTestAlgorithm]))
+	sug, _ := finder.New([]string{expect, "ample"}, finder.WithAlgorithm(algorithms[defaultTestAlgorithm]))
 	alt, _ := sug.Find("exampel")
 
 	if alt != expect {
@@ -113,7 +113,7 @@ func TestTestExactMatch(t *testing.T) {
 	}
 
 	for _, td := range cases {
-		sug, _ := finder.New([]string{"foo", "example", "CaseSensitive", "cASEsENSITIVE"}, finder.OptSetAlgorithm(algorithms[defaultTestAlgorithm]))
+		sug, _ := finder.New([]string{"foo", "example", "CaseSensitive", "cASEsENSITIVE"}, finder.WithAlgorithm(algorithms[defaultTestAlgorithm]))
 		match, score := sug.Find(td.Input)
 
 		if match != td.Expect {
@@ -136,7 +136,7 @@ func TestApproximateMatch(t *testing.T) {
 	}
 
 	for _, td := range cases {
-		sug, _ := finder.New([]string{td.Reference}, finder.OptSetAlgorithm(algorithms[defaultTestAlgorithm]))
+		sug, _ := finder.New([]string{td.Reference}, finder.WithAlgorithm(algorithms[defaultTestAlgorithm]))
 		match, _ := sug.Find(td.Input)
 
 		if match != td.Reference {
@@ -146,7 +146,7 @@ func TestApproximateMatch(t *testing.T) {
 }
 
 func BenchmarkBasicUsage(b *testing.B) {
-	sug, _ := finder.New([]string{"foo", "abr", "butterfly"}, finder.OptSetAlgorithm(algorithms[defaultTestAlgorithm]))
+	sug, _ := finder.New([]string{"foo", "abr", "butterfly"}, finder.WithAlgorithm(algorithms[defaultTestAlgorithm]))
 
 	b.Run("Direct match", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -189,7 +189,7 @@ func SuggestAlternative(email string, domains []string) (string, float64) {
 	localPart := email[:i]
 	hostname := email[i+1:]
 
-	sug, _ := finder.New(domains, finder.OptSetAlgorithm(algorithms[defaultTestAlgorithm]))
+	sug, _ := finder.New(domains, finder.WithAlgorithm(algorithms[defaultTestAlgorithm]))
 	alternative, score := sug.Find(strings.ToLower(hostname))
 
 	if score > 0.9 {

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Several algorithms to test with.
-var algorithms = map[string]finder.AlgWrapper{
+var algorithms = map[string]finder.Algorithm{
 	"Ukkonen 1/1/1": func(a, b string) float64 {
 		return -1 * float64(smetrics.Ukkonen(a, b, 1, 1, 1))
 	},

--- a/finder/find.go
+++ b/finder/find.go
@@ -6,14 +6,14 @@ import (
 	"math"
 )
 
-// AlgWrapper the type to comply with to create your own algorithm
-type AlgWrapper func(a, b string) float64
+// Algorithm the type to comply with to create your own algorithm
+type Algorithm func(a, b string) float64
 
-// Scorer is the type to find the nearest reference
-type Scorer struct {
+// Finder is the type to find the nearest reference
+type Finder struct {
 	referenceMap map[string]struct{}
 	reference    []string
-	Alg          AlgWrapper
+	Alg          Algorithm
 }
 
 // Errors

--- a/finder/find.go
+++ b/finder/find.go
@@ -21,9 +21,9 @@ var (
 	ErrNoAlgorithmDefined = errors.New("no algorithm defined")
 )
 
-// New creates a new instance of Scorer. The order of the list is significant
-func New(list []string, options ...Option) (*Scorer, error) {
-	i := &Scorer{
+// New creates a new instance of Finder. The order of the list is significant
+func New(list []string, options ...Option) (*Finder, error) {
+	i := &Finder{
 		referenceMap: make(map[string]struct{}, len(list)),
 		reference:    list,
 	}
@@ -44,12 +44,12 @@ func New(list []string, options ...Option) (*Scorer, error) {
 }
 
 // Find returns the best alternative and a score. A score of 1 means a perfect match
-func (t Scorer) Find(input string) (string, float64) {
+func (t Finder) Find(input string) (string, float64) {
 	return t.FindCtx(context.Background(), input)
 }
 
 // FindCtx is the same as Find, with context support
-func (t Scorer) FindCtx(ctx context.Context, input string) (string, float64) {
+func (t Finder) FindCtx(ctx context.Context, input string) (string, float64) {
 
 	// Exact matches
 	if _, exists := t.referenceMap[input]; exists {

--- a/finder/find_test.go
+++ b/finder/find_test.go
@@ -68,7 +68,7 @@ func TestNoInput(t *testing.T) {
 }
 
 func TestContextCancel(t *testing.T) {
-	sug, err := New([]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m"}, func(sug *Scorer) {
+	sug, err := New([]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m"}, func(sug *Finder) {
 		sug.Alg = func(a, b string) float64 {
 			time.Sleep(10 * time.Millisecond)
 			return 1
@@ -76,7 +76,7 @@ func TestContextCancel(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("Error when constructing Scorer, %s", err)
+		t.Errorf("Error when constructing Finder, %s", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)

--- a/finder/find_test.go
+++ b/finder/find_test.go
@@ -39,7 +39,7 @@ func TestOptExampleAlgorithm(t *testing.T) {
 }
 
 func TestNewWithCustomAlgorithm(t *testing.T) {
-	sug, _ := New([]string{"b"}, OptSetAlgorithm(exampleAlgorithm))
+	sug, _ := New([]string{"b"}, WithAlgorithm(exampleAlgorithm))
 
 	var score float64
 
@@ -63,7 +63,7 @@ func TestNoAlgorithm(t *testing.T) {
 }
 
 func TestNoInput(t *testing.T) {
-	sug, _ := New([]string{}, OptSetAlgorithm(exampleAlgorithm))
+	sug, _ := New([]string{}, WithAlgorithm(exampleAlgorithm))
 	sug.Find("")
 }
 

--- a/finder/option.go
+++ b/finder/option.go
@@ -4,8 +4,8 @@ package finder
 type Option func(sug *Scorer)
 
 // OptSetAlgorithm allows you to set any algorithm
-func OptSetAlgorithm(alg AlgWrapper) Option {
-	return func(s *Scorer) {
+func OptSetAlgorithm(alg Algorithm) Option {
+	return func(s *Finder) {
 		s.Alg = alg
 	}
 }

--- a/finder/option.go
+++ b/finder/option.go
@@ -1,7 +1,7 @@
 package finder
 
 // Option is the type accepted by finder to set specific options
-type Option func(sug *Scorer)
+type Option func(sug *Finder)
 
 // OptSetAlgorithm allows you to set any algorithm
 func OptSetAlgorithm(alg Algorithm) Option {

--- a/finder/option.go
+++ b/finder/option.go
@@ -3,8 +3,8 @@ package finder
 // Option is the type accepted by finder to set specific options
 type Option func(sug *Finder)
 
-// OptSetAlgorithm allows you to set any algorithm
-func OptSetAlgorithm(alg Algorithm) Option {
+// WithAlgorithm allows you to set any algorithm
+func WithAlgorithm(alg Algorithm) Option {
 	return func(s *Finder) {
 		s.Alg = alg
 	}

--- a/finder/option_test.go
+++ b/finder/option_test.go
@@ -7,7 +7,7 @@ func TestSetAlgorithm(t *testing.T) {
 		return 1
 	}
 
-	sug, err := New([]string{}, OptSetAlgorithm(veryPositiveAlg))
+	sug, err := New([]string{}, WithAlgorithm(veryPositiveAlg))
 
 	if sug.Alg == nil || err == ErrNoAlgorithmDefined {
 		t.Errorf("Expected the algorithm to be set")

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-
 	"os"
 
 	"github.com/Dynom/TySug/server"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/Dynom/TySug/server"
-	"github.com/Dynom/TySug/server/service"
+	"github.com/Dynom/TySug/server/domain"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,13 +36,13 @@ func main() {
 	logger.Level = logrus.DebugLevel
 	logger.Out = os.Stdout
 
-	d, err := service.NewDomainService(domains, logger)
+	ds, err := domain.NewService(domains, logger)
 	if err != nil {
 		panic(err)
 	}
 
 	mux := http.NewServeMux()
-	s := server.NewHTTP(d, mux, server.WithLogger(logger))
+	s := server.NewHTTP(ds, mux, server.WithLogger(logger))
 
 	err = s.ListenOnAndServe("0.0.0.0:1337")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/Dynom/TySug/server"
-	"github.com/Dynom/TySug/server/domain"
+	"github.com/Dynom/TySug/server/service"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func main() {
 	logger.Level = logrus.DebugLevel
 	logger.Out = os.Stdout
 
-	ds, err := domain.NewService(domains, logger)
+	ds, err := service.NewDomain(domains, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	s := server.NewHTTP(d, mux)
+	s := server.NewHTTP(d, mux, server.WithLogger(logger))
 
 	err = s.ListenOnAndServe("0.0.0.0:1337")
 	if err != nil {

--- a/server/domain/domain.go
+++ b/server/domain/domain.go
@@ -1,4 +1,4 @@
-package service
+package domain
 
 import (
 	"github.com/Dynom/TySug/finder"
@@ -6,31 +6,31 @@ import (
 	"github.com/xrash/smetrics"
 )
 
-// NewDomainService creates a new service
-func NewDomainService(references []string, logger *logrus.Logger, options ...finder.Option) (Domain, error) {
+// NewService creates a new service
+func NewService(references []string, logger *logrus.Logger, options ...finder.Option) (Service, error) {
 	defaults := []finder.Option{finder.OptSetAlgorithm(algJaroWinkler())}
 
 	scorer, err := finder.New(references, append(defaults, options...)...)
 	if err != nil {
-		return Domain{}, err
+		return Service{}, err
 	}
 
-	return Domain{
+	return Service{
 		scorer,
 		logger,
 	}, nil
 }
 
-// Domain is the service type
-type Domain struct {
+// Service is the service type
+type Service struct {
 	scorer *finder.Scorer
 	logger *logrus.Logger
 }
 
 // Rank returns the nearest reference
-func (ds Domain) Rank(input string) (string, float64) {
-	suggestion, score := ds.scorer.Find(input)
-	ds.logger.WithFields(logrus.Fields{
+func (s Service) Rank(input string) (string, float64) {
+	suggestion, score := s.scorer.Find(input)
+	s.logger.WithFields(logrus.Fields{
 		"input":      input,
 		"suggestion": suggestion,
 		"score":      score,

--- a/server/http.go
+++ b/server/http.go
@@ -101,7 +101,7 @@ func createRequestHandler(logger Logger, svc Service) http.HandlerFunc {
 		}
 
 		var res response
-		res.Result, res.Score = svc.Rank(req.Input)
+		res.Result, res.Score = svc.Find(req.Input)
 
 		response, err := json.Marshal(res)
 		if err != nil {

--- a/server/http.go
+++ b/server/http.go
@@ -73,8 +73,8 @@ func createRequestHandler(svc service.Interface) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, err := getRequestFromHTTPRequest(r)
 		if err != nil {
-			w.Write([]byte(err.Error()))
 			w.WriteHeader(400)
+			w.Write([]byte(err.Error()))
 			return
 		}
 
@@ -83,8 +83,8 @@ func createRequestHandler(svc service.Interface) http.HandlerFunc {
 
 		response, err := json.Marshal(res)
 		if err != nil {
-			w.Write([]byte("unable to marshal result, b00m"))
 			w.WriteHeader(500)
+			w.Write([]byte("unable to marshal result, b00m"))
 			return
 		}
 

--- a/server/http.go
+++ b/server/http.go
@@ -11,7 +11,6 @@ import (
 
 	"errors"
 
-	"github.com/Dynom/TySug/server/service"
 	"github.com/rs/cors"
 )
 
@@ -60,7 +59,7 @@ func (tss *TySugServer) ListenOnAndServe(addr string) error {
 }
 
 // NewHTTP constructs a new TySugServer
-func NewHTTP(svc service.Interface, mux *http.ServeMux, options ...Option) TySugServer {
+func NewHTTP(svc Service, mux *http.ServeMux, options ...Option) TySugServer {
 	tySug := TySugServer{
 		Logger: defaultLogger{},
 	}
@@ -89,7 +88,7 @@ func NewHTTP(svc service.Interface, mux *http.ServeMux, options ...Option) TySug
 	return tySug
 }
 
-func createRequestHandler(logger Logger, svc service.Interface) http.HandlerFunc {
+func createRequestHandler(logger Logger, svc Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, err := getRequestFromHTTPRequest(r)
 		if err != nil {

--- a/server/logging.go
+++ b/server/logging.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"fmt"
+	"os"
+)
+
+// Logger is the interface TySugServer uses for logging. Conveniently,
+// github.com/sirupsen/logrus.Logger implements this interface.
+type Logger interface {
+	Errorf(format string, args ...interface{})
+}
+
+type defaultLogger struct{}
+
+// Errorf tries to write the (formated) error message to stderr. It will
+// print to stdout if the writting to stderr fails.
+func (defaultLogger) Errorf(format string, args ...interface{}) {
+	_, err := fmt.Fprintf(os.Stderr, format, args...)
+	// We do not expect to error here, but we should print it somewhere reasonable.
+	if err != nil {
+		fmt.Println(append(
+			[]interface{}{
+				"Error while logging error: " + err.Error() + " (original message: +" + format + "+) Extra:",
+			}, args...,
+		)...)
+	}
+}

--- a/server/service.go
+++ b/server/service.go
@@ -1,0 +1,6 @@
+package server
+
+// Service is the type any service must implement
+type Service interface {
+	Rank(input string) (string, float64)
+}

--- a/server/service.go
+++ b/server/service.go
@@ -2,5 +2,5 @@ package server
 
 // Service is the type any service must implement
 type Service interface {
-	Rank(input string) (string, float64)
+	Find(input string) (string, float64)
 }

--- a/server/service/domain.go
+++ b/server/service/domain.go
@@ -8,7 +8,7 @@ import (
 
 // NewDomain creates a new service
 func NewDomain(references []string, logger *logrus.Logger, options ...finder.Option) (Service, error) {
-	defaults := []finder.Option{finder.OptSetAlgorithm(algJaroWinkler())}
+	defaults := []finder.Option{finder.WithAlgorithm(algJaroWinkler())}
 
 	scorer, err := finder.New(references, append(defaults, options...)...)
 	if err != nil {

--- a/server/service/domain.go
+++ b/server/service/domain.go
@@ -39,7 +39,7 @@ func (s Service) Rank(input string) (string, float64) {
 	return suggestion, score
 }
 
-func algJaroWinkler() finder.AlgWrapper {
+func algJaroWinkler() finder.Algorithm {
 	return func(a, b string) float64 {
 		return smetrics.JaroWinkler(a, b, .7, 4)
 	}

--- a/server/service/domain.go
+++ b/server/service/domain.go
@@ -23,13 +23,13 @@ func NewDomain(references []string, logger *logrus.Logger, options ...finder.Opt
 
 // Service is the service type
 type Service struct {
-	scorer *finder.Finder
+	finder *finder.Finder
 	logger *logrus.Logger
 }
 
-// Rank returns the nearest reference
-func (s Service) Rank(input string) (string, float64) {
-	suggestion, score := s.scorer.Find(input)
+// Find returns the nearest reference
+func (s Service) Find(input string) (string, float64) {
+	suggestion, score := s.finder.Find(input)
 	s.logger.WithFields(logrus.Fields{
 		"input":      input,
 		"suggestion": suggestion,

--- a/server/service/domain.go
+++ b/server/service/domain.go
@@ -23,7 +23,7 @@ func NewDomain(references []string, logger *logrus.Logger, options ...finder.Opt
 
 // Service is the service type
 type Service struct {
-	scorer *finder.Scorer
+	scorer *finder.Finder
 	logger *logrus.Logger
 }
 

--- a/server/service/domain.go
+++ b/server/service/domain.go
@@ -1,4 +1,4 @@
-package domain
+package service
 
 import (
 	"github.com/Dynom/TySug/finder"
@@ -6,8 +6,8 @@ import (
 	"github.com/xrash/smetrics"
 )
 
-// NewService creates a new service
-func NewService(references []string, logger *logrus.Logger, options ...finder.Option) (Service, error) {
+// NewDomain creates a new service
+func NewDomain(references []string, logger *logrus.Logger, options ...finder.Option) (Service, error) {
 	defaults := []finder.Option{finder.OptSetAlgorithm(algJaroWinkler())}
 
 	scorer, err := finder.New(references, append(defaults, options...)...)

--- a/server/service/interface.go
+++ b/server/service/interface.go
@@ -1,6 +1,0 @@
-package service
-
-// Interface is the type any service must implement
-type Interface interface {
-	Rank(input string) (string, float64)
-}


### PR DESCRIPTION
Advantages:

- `Interface` becomes `Service` (better naming)
- `Service` (formerly `Interface`) is declared where it is actually used
- No more generic `service` package name
- No more repetition (`service.NewDomainService` becomes `domain.NewService`)
